### PR TITLE
grammar: Match source-filter without whitespace

### DIFF
--- a/src/grammar.cpp
+++ b/src/grammar.cpp
@@ -1007,13 +1007,14 @@ namespace sdptransform
 					},
 
 					// a=source-filter: incl IN IP4 239.5.2.31 10.1.15.5
+					// a=source-filter:incl IN IP4 239.5.2.31 10.1.15.5
 					{
 						// name:
 						"sourceFilter",
 						// push:
 						"",
 						// reg:
-						std::regex("^source-filter:[\\s\\t]+(excl|incl) (\\S*) (IP4|IP6|\\*) (\\S*) (.*)"),
+						std::regex("^source-filter:[\\s\\t]*(excl|incl) (\\S*) (IP4|IP6|\\*) (\\S*) (.*)"),
 						// names:
 						{ "filterMode", "netType", "addressTypes", "destAddress", "srcList" },
 						// types:

--- a/test/data/st2110-20.sdp
+++ b/test/data/st2110-20.sdp
@@ -15,7 +15,7 @@ a=mediaclk:direct=0
 a=mid:primary
 m=video 50020 RTP/AVP 112
 c=IN IP4 239.101.9.10/32
-a=source-filter: incl IN IP4 239.101.9.10 192.168.101.2
+a=source-filter:incl IN IP4 239.101.9.10 192.168.101.2
 a=rtpmap:112 raw/90000
 a=fmtp:112 sampling=YCbCr-4:2:2; width=1280; height=720; interlace; exactframerate=60000/1001; depth=10; TCS=SDR; colorimetry=BT709; PM=2110GPM; SSN=ST2110-20:2017;
 a=ts-refclk:ptp=IEEE1588-2008:39-A7-94-FF-FE-07-CB-D0:37

--- a/test/parse.test.cpp
+++ b/test/parse.test.cpp
@@ -872,19 +872,22 @@ SCENARIO("st2110-20Sdp", "[parse]")
 	// No invalid node
 	REQUIRE(media.find("invalid") == media.end());
 
+	// Both primary and secondary media essence entries are found.
+	REQUIRE(media.size() == 2);
+
 	// Check sourceFilter node exists.
-	auto& video = media[0];
-	REQUIRE(video.find("sourceFilter") != video.end());
-	auto& sourceFilter = video.at("sourceFilter");
+	auto& primaryVideo = media[0];
+	REQUIRE(primaryVideo.find("sourceFilter") != primaryVideo.end());
+	auto& primarySourceFilter = primaryVideo.at("sourceFilter");
 
 	// Check expected values are present.
-	REQUIRE(sourceFilter.at("filterMode") == "incl");
-	REQUIRE(sourceFilter.at("netType") == "IN");
-	REQUIRE(sourceFilter.at("addressTypes") == "IP4");
-	REQUIRE(sourceFilter.at("destAddress") == "239.100.9.10");
-	REQUIRE(sourceFilter.at("srcList") == "192.168.100.2");
+	REQUIRE(primarySourceFilter.at("filterMode") == "incl");
+	REQUIRE(primarySourceFilter.at("netType") == "IN");
+	REQUIRE(primarySourceFilter.at("addressTypes") == "IP4");
+	REQUIRE(primarySourceFilter.at("destAddress") == "239.100.9.10");
+	REQUIRE(primarySourceFilter.at("srcList") == "192.168.100.2");
 
-	auto fmtp0Params = sdptransform::parseParams(video.at("fmtp")[0].at("config"));
+	auto fmtp0Params = sdptransform::parseParams(primaryVideo.at("fmtp")[0].at("config"));
 
 	REQUIRE(
 		fmtp0Params ==
@@ -901,6 +904,18 @@ SCENARIO("st2110-20Sdp", "[parse]")
 			"SSN"            : "ST2110-20:2017"
 		})"_json
 	);
+
+	// Check sourceFilter node exists.
+	auto& secondaryVideo = media[0];
+	REQUIRE(secondaryVideo.find("sourceFilter") != secondaryVideo.end());
+	auto& secondarySourceFilter = secondaryVideo.at("sourceFilter");
+
+	// Check expected values are present.
+	REQUIRE(secondarySourceFilter.at("filterMode") == "incl");
+	REQUIRE(secondarySourceFilter.at("netType") == "IN");
+	REQUIRE(secondarySourceFilter.at("addressTypes") == "IP4");
+	REQUIRE(secondarySourceFilter.at("destAddress") == "239.100.9.10");
+	REQUIRE(secondarySourceFilter.at("srcList") == "192.168.100.2");
 }
 
 SCENARIO("aes67", "[parse]")


### PR DESCRIPTION
Some SDP providers will not include whitespace after the colon delimiter
in the source-filter attribute.  Allow with and without the whitespace.